### PR TITLE
Add an option 'ignoreTimestampQualifier'

### DIFF
--- a/src/main/java/at/nonblocking/maven/nonsnapshot/NonSnapshotBaseMojo.java
+++ b/src/main/java/at/nonblocking/maven/nonsnapshot/NonSnapshotBaseMojo.java
@@ -102,6 +102,9 @@ abstract class NonSnapshotBaseMojo extends AbstractMojo implements Contextualiza
     @Parameter(defaultValue = DEFAULT_TIMESTAMP_QUALIFIER_PATTERN)
     private String timestampQualifierPattern = DEFAULT_TIMESTAMP_QUALIFIER_PATTERN;
 
+    @Parameter(defaultValue = "false")
+    private boolean ignoreTimestampQualifier;
+
     @Parameter
     private List<String> upstreamDependencies;
 
@@ -286,6 +289,14 @@ abstract class NonSnapshotBaseMojo extends AbstractMojo implements Contextualiza
 
     public void setTimestampQualifierPattern(String timestampQualifierPattern) {
         this.timestampQualifierPattern = timestampQualifierPattern;
+    }
+
+    public boolean isIgnoreTimestampQualifier() {
+        return ignoreTimestampQualifier;
+    }
+
+    public void setIgnoreTimestampQualifier(boolean ignoreTimestampQualifier) {
+        this.ignoreTimestampQualifier = ignoreTimestampQualifier;
     }
 
     public List<String> getUpstreamDependencies() {


### PR DESCRIPTION
Add an option 'ignoreTimestampQualifier' that allows the version to be changed but with no timestamp added.

In this case the project is always marked as dirty because there is no timestamp to check when deciding if to change the version.

We rely intensively on this plugin but we do not want the timestamp to be added to the version. As we trigger this from our CI build we already know that something changed in the repository so we do not need the check against the timestamp.